### PR TITLE
Stability update 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ This is the configuration file and should be the only file you modify. The confi
 
 ### Input
 #### `file`
-Path to the input file. 
+Path to the input file. \
+Input data must contain the following columns (case-sensitive): \
+["date_time", "WS", "USTAR", "WD", "V_SIGMA", "MO_LENGTH", "instr_height_m", "canopy_height_m", "Z0_roughness"]
+
 ```toml
 # Example (relative)
 file = "./mydata.csv"

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ geopandas       # installs shapely
 requests        # installs urllib3
 rasterio
 shapelysmooth
+tqdm            # for progress bars


### PR DESCRIPTION
This PR makes the following changes:
- Normalize day-to-day rasters according to the number of valid time-step footprints for each day.
  - Modify typing to use float16 as day-to-day raster values are now 0-1
  - Normalization is performed *after* daily raster summation.
- Normalize footprint raster according to max-normalized-overlaps
  - Change meant to show % of data represented by each individual pixel.
  - Typing is float32 to conform with shape generation in polygonization step.
- Reform error logging
  - Instead of printing all errors (previously used to display progress), a new dependency `tqdm` allows for a visual progress bar.
  - Rasterization error printing simplified to use `Exception` base class.
- Improve smoothing of footprint polygon(s)
  - Occassionally, a footprint may have a "tail" that is detached from a larger contribution polygon. Previously, this caused smoothing to break as it only accepts `Polygon` type, not `MultiPolygon`. Now, smoothing is performed on each polygon if the footprint polygon is `MultiPolygon` type.


## Before smoothing fix:
![MB_BG_S1_pi_qc_20250327_footprint_polygon](https://github.com/user-attachments/assets/ed903ba2-09ba-4734-9c9f-f282f6ec67cc)

## After smoothing fix:
![MB_BG_S1_pi_qc_20250327_footprint_polygon_fixed](https://github.com/user-attachments/assets/017909fc-c284-47df-b285-99f515a53b30)
