### PR TITLE
Change review

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The number of pixel steps to smooth the output geometry. Higher number results i
 If the resulting footprint results in disjointed polygons, uses best-effort approach to combine disjointed polygons. \
 A convex hull is performed on the polygons to create the smallest possible polygon that contains all the vertices in the geometries.
 
-![image](https://github.com/user-attachments/assets/81930ab5-e956-445c-8a3a-cca1f46f4336)
+![image](https://github.com/user-attachments/assets/9c021c80-1f08-4baa-a719-ecc256fd5865)
 
 ### `heatmap`
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ The number of pixel steps to smooth the output geometry. Higher number results i
 
 #### `coverage_union`
 
-If the resulting footprint results in disjointed polygons, uses best-effort approach to combine disjointed polygons.
+If the resulting footprint results in disjointed polygons, uses best-effort approach to combine disjointed polygons. \
+A convex hull is performed on the polygons to create the smallest possible polygon that contains all the vertices in the geometries.
 
 ### `heatmap`
 

--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ The number of pixel steps to smooth the output geometry. Higher number results i
 If the resulting footprint results in disjointed polygons, uses best-effort approach to combine disjointed polygons. \
 A convex hull is performed on the polygons to create the smallest possible polygon that contains all the vertices in the geometries.
 
+![image](https://github.com/user-attachments/assets/81930ab5-e956-445c-8a3a-cca1f46f4336)
+
 ### `heatmap`
 
 Whether to export a heatmap image showing the cummulative contribution.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ This is the configuration file and should be the only file you modify. The confi
 
 ### Input
 
+#### `run_name`
+
+An optional parameter for naming the run. This has the effect of using run_name for file outputs instead of extracting the filename from inputs.\
+If left empty, continues using filename for outputs.
+
 #### `file`
 
 Path to the input file. \

--- a/README.md
+++ b/README.md
@@ -137,12 +137,12 @@ The number of pixel steps to smooth the output geometry. Higher number results i
 
 ![image](https://github.com/user-attachments/assets/e6b3666a-2758-4f0c-b9bf-f96d075698fa)
 
-#### `coverage_union`
+#### `merge_disjointed`
 
 If the resulting footprint results in disjointed polygons, uses best-effort approach to combine disjointed polygons. \
 A convex hull is performed on the polygons to create the smallest possible polygon that contains all the vertices in the geometries.
 
-![image](https://github.com/user-attachments/assets/9c021c80-1f08-4baa-a719-ecc256fd5865)
+![image](https://github.com/user-attachments/assets/1c7f04ee-8b2c-46b6-8d77-3ec60660f58e)
 
 ### `heatmap`
 

--- a/app.py
+++ b/app.py
@@ -29,8 +29,9 @@ def main():
     # Windows Only - NT systems use \ in paths so a copied path may contain this char.
     if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
         afdat = afdat.replace("\\",'/')
-    
+        
     file = pathlib.Path(afdat)
+    output_prefix = file.stem
     
     using_reference_eto = cfg["input"]["weigh_by_eto"]
     reference_eto_file = cfg["input"]["eto_file"]
@@ -38,6 +39,8 @@ def main():
     tower_location = cfg["input"]["location"]
     blh = cfg["input"]["boundary_layer_height"]
     contour = cfg["input"]["source_contour_ratio"]
+    
+    run_name = str(cfg["input"]["name"])
     
     outputdir = cfg["output"]["output_dir"]
     resolution = cfg["output"]["spatial_resolution"]
@@ -58,6 +61,15 @@ def main():
     # Append a trailing / if missing to avoid file path issues.
     if not outputdir.endswith("/"):
         outputdir += "/"
+    
+    # Make outputdir into a Path object
+    outputdir = pathlib.Path(outputdir)
+    
+    # Create a folder in the output directory with the run name and formulate the new output directory.
+    if run_name:
+        output_prefix = run_name
+        outputdir = outputdir / run_name
+        outputdir.mkdir(exist_ok=True)
     
     if type(using_reference_eto) is not bool:
         raise TypeError("weigh_by_eto must be a boolean")
@@ -95,12 +107,12 @@ def main():
     # Create a polygon from the raster.
     polygon = footprint_raster.polygonize(overlap_threshold, 30, use_coverage_union)
     
-    pathlib.Path(f"{outputdir + file.stem}").mkdir(exist_ok=True)
-    polygon.to_file(f"{outputdir + file.stem}/{file.stem}_footprint.shp")
-    polygon.to_file(f"{outputdir}{file.stem}_footprint.geojson", driver="GeoJSON")
+    pathlib.Path(outputdir / output_prefix).mkdir(exist_ok=True)
+    polygon.to_file(outputdir / output_prefix / f"{output_prefix}_footprint.shp")
+    polygon.to_file(outputdir / f"{output_prefix}_footprint.geojson", driver="GeoJSON")
     
     if footprint_raster.daily_timeseries is not None:
-        footprint_raster.daily_timeseries.to_file(f"{outputdir}{file.stem}_footprint_timeseries.geojson", driver="GeoJSON")
+        footprint_raster.daily_timeseries.to_file(outputdir / f"{output_prefix}_footprint_timeseries.geojson", driver="GeoJSON")
     
     assert footprint_raster.raster is not None
     assert footprint_raster.geometry is not None
@@ -113,7 +125,7 @@ def main():
         ax.set_ylabel("Northing (m)")
         ax.set_title(f"Accumulated Raster\n({tower_location[0]}, {tower_location[1]})")
         fig.colorbar(im, ax=ax, label="Overlap Contribution", format=mtick.PercentFormatter(1.0))
-        plt.savefig(f"{outputdir}{file.stem}_footprint_heat.png")
+        plt.savefig(outputdir / f"{output_prefix}_footprint_heat.png")
 
     
     if produce_polygon_chart:
@@ -123,12 +135,12 @@ def main():
         ax.set_xlabel("Easting (m)")
         ax.set_ylabel("Northing (m)")
         ax.set_title(f"Tower Footprint Polygon\n({tower_location[0]}, {tower_location[1]})")
-        plt.savefig(f"{outputdir}{file.stem}_footprint_polygon.png")
+        plt.savefig(outputdir / f"{output_prefix}_footprint_polygon.png")
     
     # Export raster.
     print("Exporting footprint raster to .tif file...")
     with rasterio.open(
-        f"{outputdir}{file.stem}_footprint_raster.tif", 
+        outputdir / f"{output_prefix}_footprint_raster.tif", 
         "w+",
         transform=footprint_raster.transform,
         crs=footprint_raster.utm_crs,

--- a/app.py
+++ b/app.py
@@ -39,12 +39,9 @@ def main():
     blh = cfg["input"]["boundary_layer_height"]
     contour = cfg["input"]["source_contour_ratio"]
     
-    max_rows = cfg["input"]["max_rows"]
-    
     outputdir = cfg["output"]["output_dir"]
     resolution = cfg["output"]["spatial_resolution"]
     overlap_threshold = cfg["output"]["overlap_threshold"]
-    smoothing_factor = cfg["output"]["smoothing_factor"]
     use_coverage_union = cfg["output"]["coverage_union"]
     
     produce_heatmap = cfg["graphs"]["heatmap"]
@@ -76,8 +73,6 @@ def main():
         raise ValueError("Source contour ratio must be positive number(s)")
     if type(overlap_threshold) is not float or overlap_threshold < 0 or overlap_threshold > 1:
         raise ValueError("Overlap threshold must be a number between 0 and 1")
-    if type(smoothing_factor) is not int or smoothing_factor < 1.:
-        raise ValueError("Smoothing factor must be a number greater than or equal to 1")
     if type(produce_heatmap) is not bool:
         raise TypeError("heatmap must be a boolean")
     if type(produce_polygon_chart) is not bool:
@@ -96,9 +91,9 @@ def main():
         footprint.contour_src_pct = contour
     
     # Attach data to object then draw footprint and create a raster.
-    footprint_raster = footprint.attach(df, rdf).draw(max_rows).rasterize(resolution)
+    footprint_raster = footprint.attach(df, rdf).draw(-1).rasterize(resolution)
     # Create a polygon from the raster.
-    polygon = footprint_raster.polygonize(overlap_threshold, smoothing_factor, use_coverage_union)
+    polygon = footprint_raster.polygonize(overlap_threshold, 30, use_coverage_union)
     
     pathlib.Path(f"{outputdir + file.stem}").mkdir(exist_ok=True)
     polygon.to_file(f"{outputdir + file.stem}/{file.stem}_footprint.shp")

--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ def main():
         outputdir = cfg["output"]["output_dir"]
         resolution = cfg["output"]["spatial_resolution"]
         overlap_threshold = cfg["output"]["overlap_threshold"]
-        use_coverage_union = cfg["output"]["coverage_union"]
+        do_merge_disjointed = cfg["output"]["merge_disjointed"]
         
         produce_heatmap = cfg["graphs"]["heatmap"]
         produce_polygon_chart = cfg["graphs"]["polygon"]
@@ -109,7 +109,7 @@ def main():
     # Attach data to object then draw footprint and create a raster.
     footprint_raster = footprint.attach(df, rdf).draw(-1).rasterize(resolution)
     # Create a polygon from the raster.
-    polygon = footprint_raster.polygonize(overlap_threshold, 30, use_coverage_union)
+    polygon = footprint_raster.polygonize(overlap_threshold, 30, do_merge_disjointed)
     
     pathlib.Path(outputdir / output_prefix).mkdir(exist_ok=True)
     polygon.to_file(outputdir / output_prefix / f"{output_prefix}_footprint.shp")

--- a/app.py
+++ b/app.py
@@ -24,7 +24,27 @@ except ImportError:
 
 def main():
     cfg = tomllib.load(open("app.toml", "rb"))
-    afdat = f"{cfg['input']['file']}"
+    try:
+        afdat = f"{cfg['input']['file']}"
+        using_reference_eto = cfg["input"]["weigh_by_eto"]
+        reference_eto_file = cfg["input"]["eto_file"]
+        
+        tower_location = cfg["input"]["location"]
+        blh = cfg["input"]["boundary_layer_height"]
+        contour = cfg["input"]["source_contour_ratio"]
+        
+        run_name = str(cfg["input"]["name"])
+        
+        outputdir = cfg["output"]["output_dir"]
+        resolution = cfg["output"]["spatial_resolution"]
+        overlap_threshold = cfg["output"]["overlap_threshold"]
+        use_coverage_union = cfg["output"]["coverage_union"]
+        
+        produce_heatmap = cfg["graphs"]["heatmap"]
+        produce_polygon_chart = cfg["graphs"]["polygon"]
+    except KeyError as err:
+        print(f"The variable {str(err)} is missing from app.toml!")
+        sys.exit()
     
     # Windows Only - NT systems use \ in paths so a copied path may contain this char.
     if sys.platform.startswith("win32") or sys.platform.startswith("cygwin"):
@@ -33,22 +53,6 @@ def main():
     file = pathlib.Path(afdat)
     output_prefix = file.stem
     
-    using_reference_eto = cfg["input"]["weigh_by_eto"]
-    reference_eto_file = cfg["input"]["eto_file"]
-    
-    tower_location = cfg["input"]["location"]
-    blh = cfg["input"]["boundary_layer_height"]
-    contour = cfg["input"]["source_contour_ratio"]
-    
-    run_name = str(cfg["input"]["name"])
-    
-    outputdir = cfg["output"]["output_dir"]
-    resolution = cfg["output"]["spatial_resolution"]
-    overlap_threshold = cfg["output"]["overlap_threshold"]
-    use_coverage_union = cfg["output"]["coverage_union"]
-    
-    produce_heatmap = cfg["graphs"]["heatmap"]
-    produce_polygon_chart = cfg["graphs"]["polygon"]
     
     # Validate input data exists.
     if not file.exists():

--- a/app.toml
+++ b/app.toml
@@ -29,7 +29,7 @@ spatial_resolution      = 1
 # Overlap threshold for polygonization.
 overlap_threshold       = 0.2
 # If the output results in disjointed polygons, use best-effort approach to combine them into one.
-coverage_union = false
+merge_disjointed = false
 
 [graphs]
 # Whether to export a heatmap showing accumulated overlaps.

--- a/app.toml
+++ b/app.toml
@@ -1,5 +1,6 @@
 [input]
 # (Optional) Name of this job. Output names are superseded by this variable.
+# Leave empty (e.g. "") if you'd like to keep the tower data file name as the outputs' name prefix.
 name                    = "LettuceS2"
 
 # Path to input file.

--- a/app.toml
+++ b/app.toml
@@ -17,9 +17,6 @@ boundary_layer_height   = 2000
 # Expressed either in percentages ("80") or as fractions of 1 ("0.8"). 
 source_contour_ratio    = [90]
 
-# Maximum number of rows to read from the input file (-1 to include all).
-max_rows                = -1
-
 [output]
 # Path to output directory.
 output_dir              = "./results/"
@@ -27,10 +24,6 @@ output_dir              = "./results/"
 spatial_resolution      = 1
 # Overlap threshold for polygonization.
 overlap_threshold       = 0.2
-# Number of smoothing steps. 
-# Higher values result in a more rounded contour. 
-# Lower values result in a more jagged contour.
-smoothing_factor = 50
 # If the output results in disjointed polygons, use best-effort approach to combine them into one.
 coverage_union = false
 

--- a/app.toml
+++ b/app.toml
@@ -1,4 +1,7 @@
 [input]
+# (Optional) Name of this job. Output names are superseded by this variable.
+name                    = "LettuceS2"
+
 # Path to input file.
 file                    = "./data/MB_LET_S2_pi_qc_20250317.csv"
 # Latitude and longitude of tower location.

--- a/footprint/Footprint.py
+++ b/footprint/Footprint.py
@@ -415,7 +415,7 @@ class Footprint:
         
         combined_polygon = combined_polygon if isinstance(combined_polygon, list) else [combined_polygon]
         
-        if merge_disjointed:
+        if merge_disjointed and len(combined_polygon) > 1:
             print("Performing convex hull union...")
             # First, create a multipolygon containing all the polygons.
             mp = MultiPolygon(GeometryCollection(combined_polygon))

--- a/footprint/Footprint.py
+++ b/footprint/Footprint.py
@@ -9,7 +9,7 @@ from pyproj import Transformer
 from rasterio import features
 from rasterio.features import shapes
 from rasterio.transform import from_origin, Affine
-from shapely import MultiPolygon, coverage_union_all, coverage_is_valid
+from shapely import GeometryCollection, MultiPolygon, convex_hull
 from shapely.geometry import Polygon, shape
 from shapely.ops import unary_union
 from shapelysmooth import taubin_smooth
@@ -413,11 +413,17 @@ class Footprint:
                 footprint_segments.append(unary_union(geo))
             combined_polygon = footprint_segments
         
-        if coverage and coverage_is_valid(polygons):
-            combined_polygon = coverage_union_all(combined_polygon if isinstance(combined_polygon, list) else [combined_polygon])
+        combined_polygon = combined_polygon if isinstance(combined_polygon, list) else [combined_polygon]
+        
+        if coverage:
+            print("Performing convex hull union...")
+            # First, create a multipolygon containing all the polygons.
+            mp = MultiPolygon(GeometryCollection(combined_polygon))
+            # Then perform convex hull on it.
+            combined_polygon = [convex_hull(mp)]
         
         gdf = gpd.GeoDataFrame(
-            geometry = combined_polygon if isinstance(combined_polygon, list) else [combined_polygon], 
+            geometry = combined_polygon, 
             crs = self.utm_crs
         )
         

--- a/footprint/Footprint.py
+++ b/footprint/Footprint.py
@@ -368,7 +368,7 @@ class Footprint:
         
         return self
     
-    def polygonize(self, threshold: float = 0.0, smoothing_factor: int = 50, coverage: bool = False) -> gpd.GeoDataFrame:
+    def polygonize(self, threshold: float = 0.0, smoothing_factor: int = 50, merge_disjointed: bool = False) -> gpd.GeoDataFrame:
         """
         Create a single polygon from rasters that meet overlap threshold.
 
@@ -415,7 +415,7 @@ class Footprint:
         
         combined_polygon = combined_polygon if isinstance(combined_polygon, list) else [combined_polygon]
         
-        if coverage:
+        if merge_disjointed:
             print("Performing convex hull union...")
             # First, create a multipolygon containing all the polygons.
             mp = MultiPolygon(GeometryCollection(combined_polygon))


### PR DESCRIPTION
This PR does the following changes:
- Remove smoothing_factor variable from configuration options.
- Remove max_rows from configuration options.
- Add an optional run_name configuration option for naming the run with the effect of overwriting output file names.
- Add an optional merge_disjointed configuration option to perform a convex hull operation on disjointed polygons.
- Increased error handling for missing variables.


Example of using `merge_disjointed` for MB_BRC_S1:

![image](https://github.com/user-attachments/assets/783ca790-39b3-4af3-9423-9574372fe8f0)

Overlapping the rasters in QGIS:
![image](https://github.com/user-attachments/assets/c126b7fe-ec7e-4c4b-8628-3c761f677de2)
